### PR TITLE
Adds a config option to disable the crafting grid block placement by key

### DIFF
--- a/src/codechicken/translocator/BlockCraftingGrid.java
+++ b/src/codechicken/translocator/BlockCraftingGrid.java
@@ -33,7 +33,7 @@ import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import static codechicken.lib.vec.Vector3.*;
-import static codechicken.translocator.Translocator.config;
+import static codechicken.translocator.Translocator.disableCraftingGridKey;
 
 public class BlockCraftingGrid extends Block
 {
@@ -151,7 +151,7 @@ public class BlockCraftingGrid extends Block
     }
 
     public boolean placeBlock(World world, EntityPlayer player, int x, int y, int z, int side) {
-        if(config.getTag("disableCraftingGridKey").getBooleanValue(false))
+        if(disableCraftingGridKey)
             return false;
 
         Block block = world.getBlock(x, y, z);

--- a/src/codechicken/translocator/BlockCraftingGrid.java
+++ b/src/codechicken/translocator/BlockCraftingGrid.java
@@ -33,6 +33,7 @@ import net.minecraftforge.client.event.DrawBlockHighlightEvent;
 import net.minecraftforge.common.util.ForgeDirection;
 
 import static codechicken.lib.vec.Vector3.*;
+import static codechicken.translocator.Translocator.config;
 
 public class BlockCraftingGrid extends Block
 {
@@ -150,6 +151,9 @@ public class BlockCraftingGrid extends Block
     }
 
     public boolean placeBlock(World world, EntityPlayer player, int x, int y, int z, int side) {
+        if(config.getTag("disableCraftingGridKey").getBooleanValue(false))
+            return false;
+
         Block block = world.getBlock(x, y, z);
         if(side != 1 && block != Blocks.snow_layer)
             return false;

--- a/src/codechicken/translocator/Translocator.java
+++ b/src/codechicken/translocator/Translocator.java
@@ -30,6 +30,7 @@ public class Translocator
     public static BlockTranslocator blockTranslocator;
     public static BlockCraftingGrid blockCraftingGrid;
     public static Item itemDiamondNugget;
+    public static boolean disableCraftingGridKey;
 
     @EventHandler
     public void preInit(FMLPreInitializationEvent event) {
@@ -38,6 +39,7 @@ public class Translocator
 
     @EventHandler
     public void init(FMLInitializationEvent event) {
+        disableCraftingGridKey = config.getTag("disable-crafting-grid-key").setComment("Set to true to disable placement of crafting grids by keyboard shortcut.").getBooleanValue(false);
         proxy.init();
     }
 }


### PR DESCRIPTION
If a server owner doesn't like this feature for some reason, he will be able to disable it with this config option.

When disabled on the server but enabled on the client it will still create a ghost crafting grid block on the client that will disappear on block update.

When enabled on the server but disabled on the client the key will do nothing, but an other player with this configuration enabled will be able to place it by key normally.

I did this change because I was having duplication issues on my server and people was using it to annoy other players by placing many crafting grids on other player's houses (bypassing the protections)
